### PR TITLE
Prevent browser refreshes from wiping out questions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ const initAuthValue = JSON.parse(sessionStorage.getItem('isAuthenticated'));
 const initQuestionId = sessionStorage.getItem('questionId');
 const initTimer = sessionStorage.getItem('timer');
 const initUsernameValue = sessionStorage.getItem('username');
+const initWager = sessionStorage.getItem('wager');
 
 //conf
 export const questionTotalTime = 60;
@@ -28,7 +29,7 @@ export const TimerContext = createContext(initTimer);
 export const ToastMessageContext = createContext();
 export const TopTenContext = createContext();
 export const UsernameContext = createContext(initUsernameValue);
-export const WagerContext = createContext();
+export const WagerContext = createContext(initWager);
 
 export default function App() {
 
@@ -36,10 +37,10 @@ export default function App() {
 	const [ username, setUsername ] = useState(initUsernameValue);
 	const [ question, setQuestion ] = useState();
 	const [ score, setScore ] = useState();
-	const [ time, setTime ] = useState();
+	const [ time, setTime ] = useState(initTimer);
 	const [ topTen, setTopTen ] = useState();
 	const [ toastMessage, setToastMessage ] = useState();
-	const [ wager, setWager ] = useState();
+	const [ wager, setWager ] = useState(initWager);
 
 	useEffect(() => {
 		if (isAuthenticated) {
@@ -56,12 +57,7 @@ export default function App() {
 			API.post(trebekbotUrls.question, {"questionId": initQuestionId})
 				.then((response) => {
 					setQuestion(JSON.parse(response.data));
-					setTime(initTimer);
 				});
-		}
-		else {
-            sessionStorage.setItem('timer', 0);
-            sessionStorage.setItem('questionId', null);
 		}
 	}, [isAuthenticated]);
 

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,8 @@ import API from 'TrebekbotAPI';
 import { trebekbotUrls } from 'TrebekbotAPI';
 
 const initAuthValue = JSON.parse(sessionStorage.getItem('isAuthenticated'));
+const initQuestionId = sessionStorage.getItem('questionId');
+const initTimer = sessionStorage.getItem('timer');
 const initUsernameValue = sessionStorage.getItem('username');
 
 //conf
@@ -22,7 +24,7 @@ export const dailyDoubleTotalTime = 60;
 export const AuthContext = createContext(initAuthValue);
 export const QuestionContext = createContext();
 export const ScoreContext = createContext();
-export const TimerContext = createContext();
+export const TimerContext = createContext(initTimer);
 export const ToastMessageContext = createContext();
 export const TopTenContext = createContext();
 export const UsernameContext = createContext(initUsernameValue);
@@ -42,14 +44,25 @@ export default function App() {
 	useEffect(() => {
 		if (isAuthenticated) {
 			API.get(trebekbotUrls.topTen)
-			.then((response) => {
-				setTopTen(response.data);
-			});
+				.then((response) => {
+					setTopTen(response.data);
+				});
 			API.get(trebekbotUrls.score)
 				.then((response) => {
 					setScore(response.data);
-			});	
-			}
+				});	
+		}
+		if (initTimer && initQuestionId) {
+			API.post(trebekbotUrls.question, {"questionId": initQuestionId})
+				.then((response) => {
+					setQuestion(JSON.parse(response.data));
+					setTime(initTimer);
+				});
+		}
+		else {
+            sessionStorage.setItem('timer', 0);
+            sessionStorage.setItem('questionId', null);
+		}
 	}, [isAuthenticated]);
 
 	return (

--- a/src/TrebekbotAPI.js
+++ b/src/TrebekbotAPI.js
@@ -11,8 +11,7 @@ export default axios.create({
 export const trebekbotUrls = {
   'judgeAnswer': '/game/judge/',
   'login': '/game/login/',
-  'getQuestion': '/game/question/',
+  'question': '/game/question/',
   'topTen': '/game/topten/',
   'score': '/game/score'
 }
-

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -65,7 +65,7 @@ export default function Question () {
     };
 
     function loadQuestion() {
-        API.get(trebekbotUrls.getQuestion)
+        API.get(trebekbotUrls.question)
             .then(res => {
                 let parsedData = JSON.parse(res.data);
                 setTime(60);
@@ -73,6 +73,7 @@ export default function Question () {
                 let [audioLinkArray, visualLinkArray] = arrayAudioVisualLinks(parsedData.valid_links);
                 setAudioLinks(audioLinkArray);
                 setVisualLinks(visualLinkArray);
+                sessionStorage.setItem('questionId', parsedData.id);
             }
         )
     };

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -30,6 +30,7 @@ export default function Timer () {
             setQuestion();
             sessionStorage.setItem('timer', 0);
             sessionStorage.setItem('questionId', null);
+            sessionStorage.setItem('wager', 0);
         }
         
         return () => clearInterval(timer);

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -19,6 +19,7 @@ export default function Timer () {
 
         const timer = setInterval(() => {
             setTime(time - 1);
+            sessionStorage.setItem('timer', time);
         }, 1000);
 
         if (time === 0) {
@@ -27,6 +28,8 @@ export default function Timer () {
             }
             clearInterval(timer);
             setQuestion();
+            sessionStorage.setItem('timer', 0);
+            sessionStorage.setItem('questionId', null);
         }
         
         return () => clearInterval(timer);

--- a/src/components/forms/AnswerForm.js
+++ b/src/components/forms/AnswerForm.js
@@ -48,6 +48,8 @@ export default function AnswerForm() {
 				setWager(0);
 				setTime(0);
 				setQuestion();
+				sessionStorage.setItem('timer', 0);
+				sessionStorage.setItem('questionId', null);
 			}
 		})
 	}

--- a/src/components/modals/DailyDouble.js
+++ b/src/components/modals/DailyDouble.js
@@ -58,6 +58,7 @@ export default function DailyDoubleModal() {
         else {
             setWager(wagerField);
             setTime(60);
+            sessionStorage.setItem('wager', wagerField);
         }
     }
 


### PR DESCRIPTION
This PR prevents browser refreshes from wiping out questions by persisting the timer, current DD wager, and question id in session storage.